### PR TITLE
Fix data normalization (master version is removing words and is not properly handling abbreviations)

### DIFF
--- a/scutils/fs02utils.py
+++ b/scutils/fs02utils.py
@@ -42,6 +42,7 @@ Created on Sun Apr 5 2020
 
 import os, glob, sys, json, re
 from datetime import datetime
+from string import ascii_letters
 from subprocess import Popen, PIPE, STDOUT
 
 
@@ -153,15 +154,17 @@ def readList(readPath):
 
 
 def get_json_txtstr(file_path):
+    # to allow words like let's, we're, etc
+    english_chars = set(ascii_letters + "'")
     content = []
     with open(file_path,'r') as file:  
         data = json.load(file)
         if not type(data)==list:
             data = [data]
         for utt in data:
-            words = re.sub(r'(?<!\w)([A-Z])\.', r'\1 ', utt['words'])
+            words = re.sub(r'[,.;:@#?!&$]+', ' ', utt['words'])
             words = words.replace('[unk]','').upper()
-            words = ' '.join(e for e in words.split() if e.isalnum())
+            words = ' '.join(e for e in words.split() if english_chars.issuperset(e))
             content.append(words)
     content = ' '.join(content)
     content = re.sub(' +', ' ',content)

--- a/scutils/fs02utils.py
+++ b/scutils/fs02utils.py
@@ -159,7 +159,7 @@ def get_json_txtstr(file_path):
         if not type(data)==list:
             data = [data]
         for utt in data:
-            words = re.sub(r'(?<!\w)([A-Z])\.', r'\1', utt['words'])
+            words = re.sub(r'(?<!\w)([A-Z])\.', r'\1 ', utt['words'])
             words = words.replace('[unk]','').upper()
             words = ' '.join(e for e in words.split() if e.isalnum())
             content.append(words)


### PR DESCRIPTION
There are multiple abbreviations in both train and A11 corpora, so unifying the scoring approach would be quite helpful.
At the moment scoring tool converts both reference and hypothesis multi-character abbreviations to a single word.

For example, this is happening in master:
```
>>> re.sub(r'(?<!\w)([A-Z])\.', r'\1', "FLIGHT A.B.C.")
'FLIGHT ABC '
```

The PR proposal is to do conversion as follows for the evaluation
```
>>> re.sub(r'(?<!\w)([A-Z])\.', r'\1 ', "FLIGHT A.B.C.")
'FLIGHT A B C '
```

Let me know if that makes sense.

Thanks!